### PR TITLE
cumulative endless stats with regular game + stats UI polish

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ export default function App() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [currentView, setCurrentView] = useState('menu'); // 'menu', 'auth', 'game', 'stats'
+  const [prevGameStats, setPrevGameStats] = useState(null);
 
   useEffect(() => {
     checkAuthStatus();
@@ -65,6 +66,7 @@ export default function App() {
   };
 
   const backToMenu = () => {
+    setPrevGameStats(null);
     setCurrentView('menu');
   };
 
@@ -72,7 +74,8 @@ export default function App() {
     setCurrentView('game');
   };
 
-  const startEndless = () => {
+  const startEndless = (stats = null) => {
+    setPrevGameStats(stats);
     setCurrentView('endless');
   };
 
@@ -97,7 +100,7 @@ export default function App() {
 
   // Endless mode view
   if (currentView === 'endless') {
-    return <EndlessMode onQuit={backToMenu} />;
+    return <EndlessMode onQuit={backToMenu} prevGameStats={prevGameStats} />;
   }
 
   // Statistics view

--- a/frontend/src/EndlessMode.jsx
+++ b/frontend/src/EndlessMode.jsx
@@ -406,7 +406,7 @@ function BouncingLevelGame({
   );
 }
 
-export default function EndlessMode({ onQuit }) {
+export default function EndlessMode({ onQuit, prevGameStats }) {
   const [state, setState] = useState(freshState);
 
   function onTileClick(rowIndex, tileIndex) {
@@ -465,16 +465,30 @@ export default function EndlessMode({ onQuit }) {
           averageColorDifference: state.averageDifference,
         };
         const allLevelStats = [...state.completedRoundStats, failedStat];
-        const finalSmallestDiff = Math.min(state.smallestDiffSoFar, state.levelMinDiff);
-        const finalSmallestDiffExample = finalSmallestDiff < state.smallestDiffSoFar
+        const endlessSmallestDiff = Math.min(state.smallestDiffSoFar, state.levelMinDiff);
+        const endlessSmallestExample = endlessSmallestDiff < state.smallestDiffSoFar
           ? state.levelMinDiffExample
           : state.smallestDiffExampleSoFar;
-        const totalTime = allLevelStats.reduce((sum, s) => sum + s.timeSeconds, 0);
+
+        // Merge with previous game stats (levels 1-10) if the player came from a regular game
+        const prevSmallest = prevGameStats?.smallestDifference ?? Infinity;
+        const combinedSmallestDiff = Math.min(endlessSmallestDiff, prevSmallest);
+        const combinedSmallestExample = combinedSmallestDiff <= endlessSmallestDiff
+          ? endlessSmallestExample
+          : prevGameStats.smallestDifferenceExample;
+
+        const regularStats = (prevGameStats?.levelStats || []).map(s => ({ ...s, origin: 'game' }));
+        const endlessStats = allLevelStats.map(s => ({ ...s, origin: 'endless' }));
+
+        const endlessTime = allLevelStats.reduce((sum, s) => sum + s.timeSeconds, 0);
+        const totalTime = endlessTime + (prevGameStats?.totalTime ?? 0);
+
         const gameOverStats = {
-          levelStats: allLevelStats,
-          smallestDifference: finalSmallestDiff === Infinity ? null : finalSmallestDiff,
-          smallestDifferenceExample: finalSmallestDiff === Infinity ? null : finalSmallestDiffExample,
+          levelStats: [...regularStats, ...endlessStats],
+          smallestDifference: combinedSmallestDiff === Infinity ? null : combinedSmallestDiff,
+          smallestDifferenceExample: combinedSmallestDiff === Infinity ? null : combinedSmallestExample,
           totalTime,
+          hasRegularGame: regularStats.length > 0,
         };
         setState(prev => ({
           ...prev,

--- a/frontend/src/Game.jsx
+++ b/frontend/src/Game.jsx
@@ -208,7 +208,7 @@ export default function Game({ onQuit, onPlayEndless }) {
             className="menu-button primary"
             onClick={() => {
               setShowEndlessChoice(false);
-              onPlayEndless();
+              onPlayEndless(gameStats);
             }}
           >
             Play Endless Mode

--- a/frontend/src/GameStats.jsx
+++ b/frontend/src/GameStats.jsx
@@ -5,8 +5,13 @@ export default function GameStats({ stats, onPlayAgain, isEndless = false, onQui
 
   if (!stats) return null;
 
-  const { levelStats, smallestDifference, smallestDifferenceExample, totalTime } = stats;
-  const completedLevels = levelStats.filter(level => !level.failed);
+  const { levelStats, smallestDifference, smallestDifferenceExample, totalTime, hasRegularGame } = stats;
+  const endlessLevelStats = isEndless && hasRegularGame
+    ? levelStats.filter(level => level.origin === 'endless')
+    : levelStats;
+  const completedLevels = isEndless
+    ? endlessLevelStats.filter(level => !level.failed)
+    : levelStats.filter(level => !level.failed);
   const totalStrikes = levelStats.reduce((sum, level) => sum + level.strikes, 0);
   const averageTimePerLevel = completedLevels.length > 0
     ? completedLevels.reduce((sum, level) => sum + level.timeSeconds, 0) / completedLevels.length
@@ -230,14 +235,12 @@ export default function GameStats({ stats, onPlayAgain, isEndless = false, onQui
 
   return (
     <div className="stats-container">
-      <h2>{isEndless ? 'Endless Mode Statistics' : 'Game Statistics'}</h2>
-
       <button className="play-again-button" onClick={onPlayAgain}>
         Play Again
       </button>
 
       {isEndless && onQuit && (
-        <button className="menu-button secondary" style={{ display: 'block', margin: '0 auto 1rem' }} onClick={onQuit}>
+        <button className="menu-button secondary" style={{ display: 'block', margin: '0.75rem auto 1rem' }} onClick={onQuit}>
           Back to Menu
         </button>
       )}
@@ -275,6 +278,8 @@ export default function GameStats({ stats, onPlayAgain, isEndless = false, onQui
           <div className="share-message">{shareMessage}</div>
         )}
       </div>
+
+      <h2>{isEndless ? 'Endless Mode Statistics' : 'Game Statistics'}</h2>
 
       {/* Overall Stats */}
       <div className="stats-section">
@@ -323,24 +328,41 @@ export default function GameStats({ stats, onPlayAgain, isEndless = false, onQui
 
       {/* Per-Level/Round Breakdown */}
       <div className="stats-section">
-        <h3>{isEndless ? 'Round Breakdown' : 'Level Breakdown'}</h3>
+        <h3>{isEndless && hasRegularGame ? 'Full Breakdown' : isEndless ? 'Round Breakdown' : 'Level Breakdown'}</h3>
         <div className="level-stats-table">
           <div className="table-header">
-            <span>{isEndless ? 'Round' : 'Level'}</span>
+            <span>#</span>
             <span>Result</span>
             <span>Time</span>
             <span>Strikes</span>
             <span>Difficulty</span>
           </div>
-          {levelStats.map((level, index) => (
-            <div key={index} className={`table-row ${level.failed ? 'failed-level' : ''}`}>
-              <span>{level.level}</span>
-              <span className="result-cell">{getLevelIndicator(level)}</span>
-              <span>{formatTime(level.timeSeconds)}</span>
-              <span>{level.strikes}</span>
-              <span>{Math.round(level.averageColorDifference)}%</span>
-            </div>
-          ))}
+          {levelStats.map((level, index) => {
+            const prevOrigin = index > 0 ? levelStats[index - 1].origin : null;
+            const showGameHeader = isEndless && hasRegularGame && index === 0 && level.origin === 'game';
+            const showEndlessHeader = isEndless && hasRegularGame && level.origin === 'endless' && prevOrigin === 'game';
+            return (
+              <React.Fragment key={index}>
+                {showGameHeader && (
+                  <div className="table-section-divider">
+                    <span>Regular Game</span>
+                  </div>
+                )}
+                {showEndlessHeader && (
+                  <div className="table-section-divider">
+                    <span>Endless Mode</span>
+                  </div>
+                )}
+                <div className={`table-row ${level.failed ? 'failed-level' : ''}`}>
+                  <span>{level.origin === 'endless' ? `R${level.level}` : level.level}</span>
+                  <span className="result-cell">{getLevelIndicator(level)}</span>
+                  <span>{formatTime(level.timeSeconds)}</span>
+                  <span>{level.strikes}</span>
+                  <span>{Math.round(level.averageColorDifference)}%</span>
+                </div>
+              </React.Fragment>
+            );
+          })}
         </div>
       </div>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -397,7 +397,7 @@ body {
 .stats-container h2 {
   text-align: center;
   color: #00fff0;
-  margin-bottom: 30px;
+  margin: 20px 0 20px;
   font-size: 1.4rem;
   text-transform: uppercase;
   letter-spacing: 2px;
@@ -708,6 +708,27 @@ body {
   background: #1a1116;
 }
 
+.level-stats-table .table-section-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 15px;
+  background: #111116;
+  color: #00fff0;
+  font-size: 0.75rem;
+  font-weight: bold;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-top: 1px solid #252530;
+}
+
+.level-stats-table .table-section-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #252530;
+}
+
 .level-stats-table .table-row:hover {
   background: #1a1a22;
 }
@@ -715,7 +736,7 @@ body {
 /* Play again */
 .play-again-button {
   display: block;
-  margin: 30px auto 0;
+  margin: 20px auto 0;
   padding: 12px 30px;
   font-size: 1.2rem;
   background: #00fff0;


### PR DESCRIPTION
- Pass regular game stats into EndlessMode when transitioning from level 10
- Merge level 1-10 stats with endless rounds on the game-over screen
- Show "Regular Game" / "Endless Mode" section dividers in breakdown table
- Move statistics h2 header below the Share section, above Overall Performance
- Separate Play Again and Back to Menu buttons with top margin