### PR TITLE
Add Vercel Analytics and admin stats endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -456,6 +456,74 @@ app.get("/api/stats/aggregate", authenticateToken, async (req, res) => {
   }
 });
 
+// Admin stats endpoint - protected by ADMIN_SECRET env variable
+app.get('/api/admin/stats', async (req, res) => {
+  const secret = req.headers['x-admin-secret'] || req.query.secret;
+  if (!secret || secret !== process.env.ADMIN_SECRET) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  if (!db) {
+    return res.status(503).json({ error: 'Database unavailable' });
+  }
+
+  try {
+    const [users, signups, games, activity, peakHours] = await Promise.all([
+      // Total registered users
+      db.query(`SELECT COUNT(*) as total FROM users`),
+
+      // Signups per day for the last 30 days
+      db.query(`
+        SELECT DATE(created_at) as date, COUNT(*) as count
+        FROM users
+        WHERE created_at > NOW() - INTERVAL '30 days'
+        GROUP BY date ORDER BY date
+      `),
+
+      // Game totals
+      db.query(`
+        SELECT
+          COUNT(*) as total_games,
+          COUNT(CASE WHEN game_completed = true THEN 1 END) as completed_games,
+          COUNT(DISTINCT user_id) as unique_players
+        FROM game_sessions
+      `),
+
+      // Active players (last 24h / 7d / 30d)
+      db.query(`
+        SELECT
+          COUNT(DISTINCT user_id) FILTER (WHERE started_at > NOW() - INTERVAL '1 day') as active_24h,
+          COUNT(DISTINCT user_id) FILTER (WHERE started_at > NOW() - INTERVAL '7 days') as active_7d,
+          COUNT(DISTINCT user_id) FILTER (WHERE started_at > NOW() - INTERVAL '30 days') as active_30d
+        FROM game_sessions
+      `),
+
+      // Peak hours - most concurrent sessions (approximated by sessions started per hour)
+      db.query(`
+        SELECT DATE_TRUNC('hour', started_at) as hour, COUNT(*) as sessions
+        FROM game_sessions
+        GROUP BY hour ORDER BY sessions DESC LIMIT 10
+      `)
+    ]);
+
+    res.json({
+      users: {
+        total: parseInt(users.rows[0].total),
+        signupsByDay: signups.rows
+      },
+      games: {
+        total: parseInt(games.rows[0].total_games),
+        completed: parseInt(games.rows[0].completed_games),
+        uniquePlayers: parseInt(games.rows[0].unique_players)
+      },
+      activity: activity.rows[0],
+      peakHours: peakHours.rows
+    });
+  } catch (error) {
+    console.error('Admin stats error:', error);
+    res.status(500).json({ error: 'Failed to fetch stats' });
+  }
+});
+
 // Health check endpoint
 app.get('/health', (req, res) => {
   res.json({ status: 'OK', timestamp: new Date().toISOString() });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.6.1",
+    "axios": "^1.4.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "axios": "^1.4.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Analytics } from "@vercel/analytics/react";
 import Game from "./Game";
 import AuthForm from "./AuthForm";
 import AggregateStats from "./AggregateStats";
@@ -79,104 +80,100 @@ export default function App() {
     setCurrentView('endless');
   };
 
+  let content;
+
   if (loading) {
-    return (
+    content = (
       <div className="app-container">
         <h1>Color Tile Game</h1>
         <p>Loading...</p>
       </div>
     );
-  }
-
-  // Authentication view
-  if (currentView === 'auth') {
-    return <AuthForm onAuthSuccess={handleAuthSuccess} onPlayAsGuest={playAsGuest} />;
-  }
-
-  // Game view
-  if (currentView === 'game') {
-    return <Game onQuit={backToMenu} onPlayEndless={startEndless} />;
-  }
-
-  // Endless mode view
-  if (currentView === 'endless') {
-    return <EndlessMode onQuit={backToMenu} prevGameStats={prevGameStats} />;
-  }
-
-  // Statistics view
-  if (currentView === 'stats' && user) {
-    return <AggregateStats user={user} onBack={backToMenu} />;
-  }
-
-  // Main menu
-  return (
-    <div className="app-container">
-      <div className="header">
-        <h1>Color Tile Game</h1>
-        {user ? (
-          <div className="user-info">
-            <span>Welcome back, {user.username}!</span>
-            <button onClick={handleLogout} className="logout-button">
-              Logout
-            </button>
-          </div>
-        ) : (
-          <div className="auth-prompt">
-            <span>Sign in to track your progress!</span>
-          </div>
-        )}
-      </div>
-
-      <TileCarousel />
-
-      <div className="menu-container">
-        <div className="menu-buttons">
-          <button className="menu-button primary" onClick={startGame}>
-            Start New Game
-          </button>
-          
+  } else if (currentView === 'auth') {
+    content = <AuthForm onAuthSuccess={handleAuthSuccess} onPlayAsGuest={playAsGuest} />;
+  } else if (currentView === 'game') {
+    content = <Game onQuit={backToMenu} onPlayEndless={startEndless} />;
+  } else if (currentView === 'endless') {
+    content = <EndlessMode onQuit={backToMenu} prevGameStats={prevGameStats} />;
+  } else if (currentView === 'stats' && user) {
+    content = <AggregateStats user={user} onBack={backToMenu} />;
+  } else {
+    content = (
+      <div className="app-container">
+        <div className="header">
+          <h1>Color Tile Game</h1>
           {user ? (
-            <button className="menu-button secondary" onClick={showStats}>
-              View Statistics
-            </button>
+            <div className="user-info">
+              <span>Welcome back, {user.username}!</span>
+              <button onClick={handleLogout} className="logout-button">
+                Logout
+              </button>
+            </div>
           ) : (
-            <button className="menu-button secondary" onClick={showAuth}>
-              Sign In / Register
-            </button>
-          )}
-          
-          {!user && (
-            <button className="menu-button tertiary" onClick={playAsGuest}>
-              Play as Guest
-            </button>
-          )}
-
-          <button className="menu-button tertiary" onClick={startEndless}>
-            Endless Mode
-          </button>
-        </div>
-
-        <div className="game-description">
-          <h3>How to Play</h3>
-          <p>
-            Find the tile that's slightly different in color from the others in each row. 
-            You have 3 strikes per game and 10 levels to complete. 
-            Each level gets progressively harder with more subtle color differences!
-          </p>
-          
-          {user && (
-            <div className="user-benefits">
-              <h4>Signed In Benefits:</h4>
-              <ul>
-                <li>Track your progress across all games</li>
-                <li>View detailed performance statistics</li>
-                <li>See your personal bests and hardest challenges</li>
-                <li>Analyze your performance by level</li>
-              </ul>
+            <div className="auth-prompt">
+              <span>Sign in to track your progress!</span>
             </div>
           )}
         </div>
+
+        <TileCarousel />
+
+        <div className="menu-container">
+          <div className="menu-buttons">
+            <button className="menu-button primary" onClick={startGame}>
+              Start New Game
+            </button>
+
+            {user ? (
+              <button className="menu-button secondary" onClick={showStats}>
+                View Statistics
+              </button>
+            ) : (
+              <button className="menu-button secondary" onClick={showAuth}>
+                Sign In / Register
+              </button>
+            )}
+
+            {!user && (
+              <button className="menu-button tertiary" onClick={playAsGuest}>
+                Play as Guest
+              </button>
+            )}
+
+            <button className="menu-button tertiary" onClick={startEndless}>
+              Endless Mode
+            </button>
+          </div>
+
+          <div className="game-description">
+            <h3>How to Play</h3>
+            <p>
+              Find the tile that's slightly different in color from the others in each row.
+              You have 3 strikes per game and 10 levels to complete.
+              Each level gets progressively harder with more subtle color differences!
+            </p>
+
+            {user && (
+              <div className="user-benefits">
+                <h4>Signed In Benefits:</h4>
+                <ul>
+                  <li>Track your progress across all games</li>
+                  <li>View detailed performance statistics</li>
+                  <li>See your personal bests and hardest challenges</li>
+                  <li>Analyze your performance by level</li>
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
-    </div>
+    );
+  }
+
+  return (
+    <>
+      <Analytics />
+      {content}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `@vercel/analytics` to the frontend — `<Analytics />` is rendered at the root level so it tracks all views (menu, game, endless, auth, stats)
- Adds `/api/admin/stats` endpoint to the backend, protected by `ADMIN_SECRET` env var (already set in Railway)
- Admin stats returns: total users, signups by day (last 30d), games played/completed, unique players, active users (24h/7d/30d), peak hours

## Test plan
- [ ] Merge and wait for Railway to redeploy
- [ ] Hit `https://<RAILWAY_PUBLIC_DOMAIN>/api/admin/stats?secret=<ADMIN_SECRET>` and confirm JSON response
- [ ] Check Vercel Analytics tab after a day for visitor data

🤖 Generated with [Claude Code](https://claude.com/claude-code)